### PR TITLE
Add user list pane to the admin console

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ See the [Linting](#linting) section to make sure the linter is running in WebSto
 
 #### Git Workflow
 
-The main branch is master. When some work needs to be done, you will branch off from master using the 
+The main branch is master, which will hold the current production version.
+When some work needs to be done, you will branch off from **dev** using the 
 naming convention `<initials>-<feature-name>` for your branch.
-After the work has completed, the developer should create a PR in Github to merge the branch back into master and notify the project lead
-to review. Any PR's with linting issues will be rejected so make sure you run the linter via `yarn run lint` before submitting a PR. 
+After the work has completed, the developer should create a PR in Github to merge the branch back into dev and notify the project lead
+to review. Please make sure to submit a PR to merge into **dev** branch and not master. Any PR's with linting issues will be rejected so
+make sure you run the linter via `yarn run lint` before submitting a PR. 
 To run the linter while developing run `yarn run watch:lint`.
 
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ See the [Linting](#linting) section to make sure the linter is running in WebSto
 #### Git Workflow
 
 The main branch is master, which will hold the current production version.
-When some work needs to be done, you will branch off from **dev** using the 
-naming convention `<initials>-<feature-name>` for your branch.
+When some work needs to be done, you will branch off from **master** using the 
+naming convention `<initials>/<feature-name>` for your branch.
 After the work has completed, the developer should create a PR in Github to merge the branch back into dev and notify the project lead
 to review. Please make sure to submit a PR to merge into **dev** branch and not master. Any PR's with linting issues will be rejected so
 make sure you run the linter via `yarn run lint` before submitting a PR. 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -77,6 +77,10 @@ export async function getModule(id: number) {
   return ( await api.get<Module>(`/modules/${id}`)).data;
 }
 
+export async function getUserList() {
+  return ( await api.get<User[]>(`/user/`) ).data;
+}
+
 export async function login(email: string, password: string): Promise<AxiosResponse<UserWithToken>> {
   const resp = await api.post<UserWithToken>('/user/authenticate', {email: email, password: password });
   setToken(resp.data.token);

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -3,7 +3,7 @@ import {Layout} from '../../pages/Layout/Layout';
 import {Col, ListGroup, ListGroupItem, Row, TabContainer, TabContent} from 'react-bootstrap';
 import {StatisticsPane} from './StatisticsPane';
 import {ClusterPane} from './ClusterPane';
-import {UsersPane} from './UsersPane';
+import UsersPane from './UsersPane';
 
 interface AdminPanelLayoutProps {
   defaultActivePanel?: '#statistics'|'#cluster-management'|'#user-management';

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -16,18 +16,18 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
     <TabContainer defaultActiveKey={(props.defaultActivePanel) ? props.defaultActivePanel : '#statistics'}>
       <Row>
         <Col xs={4}>
-          <ListGroup style={styles.listGroup}>
+          <ListGroup style={{marginTop: '20px'}}>
             <ListGroup.Item action={true} href='#statistics'>
-              <span>Application Statistics</span>
+              Application Statistics
             </ListGroup.Item>
             <ListGroup.Item action={true} href='#cluster-management'>
-              <span>Cluster Management</span>
+              Cluster Management
               </ListGroup.Item>
             <ListGroup.Item action={true} href='#user-management'>
-              <span>User Management</span>
+              User Management
             </ListGroup.Item>
             <ListGroup.Item action={true} href='#downtime-scheduler'>
-              <span>Downtime Scheduler</span>
+              Downtime Scheduler
             </ListGroup.Item>
           </ListGroup>
         </Col>
@@ -43,12 +43,3 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
     </TabContainer>
   </Layout>
 );
-
-const styles = {
-  listGroup: {
-    marginTop: '20px',
-    '&.active': {
-      backgroundColor: '#d9534f'
-    }
-  }
-};

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Layout} from '../../pages/Layout/Layout';
-import {Col, ListGroup, Row, TabContainer, TabContent} from 'react-bootstrap';
+import {Col, ListGroup, Row, TabContainer, TabContent, TabPane} from 'react-bootstrap';
 import {StatisticsPane} from './StatisticsPane';
 import {ClusterPane} from './ClusterPane';
 import UsersPane from './UsersPane';
@@ -10,6 +10,13 @@ interface AdminPanelLayoutProps {
   defaultActivePanel?: '#statistics'|'#cluster-management'|'#user-management';
 }
 
+const panes = [
+  {label: 'Application Statistics', eventKey: '#statistics', component: StatisticsPane},
+  {label: 'Cluster Management', eventKey: '#cluster-management', component: ClusterPane},
+  {label: 'User Management', eventKey: '#user-management', component: UsersPane},
+  {label: 'Downtime Scheduler', eventKey: '#downtime-scheduler', component: DowntimeScheduler}
+];
+
 export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
   <Layout>
     <h1>Admin Console</h1>
@@ -17,26 +24,20 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
       <Row>
         <Col xs={4}>
           <ListGroup style={{marginTop: '20px'}}>
-            <ListGroup.Item action={true} href='#statistics'>
-              Application Statistics
-            </ListGroup.Item>
-            <ListGroup.Item action={true} href='#cluster-management'>
-              Cluster Management
+            {panes.map(pane => (
+              <ListGroup.Item key={pane.eventKey} action={true} href={pane.eventKey}>
+                {pane.label}
               </ListGroup.Item>
-            <ListGroup.Item action={true} href='#user-management'>
-              User Management
-            </ListGroup.Item>
-            <ListGroup.Item action={true} href='#downtime-scheduler'>
-              Downtime Scheduler
-            </ListGroup.Item>
+            ))}
           </ListGroup>
         </Col>
         <Col xs={8}>
           <TabContent>
-            <StatisticsPane/>
-            <ClusterPane/>
-            <UsersPane/>
-            <DowntimeScheduler/>
+            {panes.map(pane => (
+              <TabPane key={pane.eventKey} eventKey={pane.eventKey}>
+                {pane.component}
+              </TabPane>
+            ))}
           </TabContent>
         </Col>
       </Row>

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -15,7 +15,7 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
           <ListGroup>
             <ListGroupItem variant='danger' action={true} href='#statistics'>Application Statistics</ListGroupItem>
             <ListGroupItem variant='danger' action={true} href='#cluster-management'>Cluster Management</ListGroupItem>
-            <ListGroupItem variant='danger' action={true} href='#user-management'>Cluster Management</ListGroupItem>
+            <ListGroupItem variant='danger' action={true} href='#user-management'>User Management</ListGroupItem>
           </ListGroup>
         </Col>
         <Col xs={8}>

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {Layout} from '../../pages/Layout/Layout';
+import {Col, ListGroup, ListGroupItem, TabContainer, TabContent, TabPane} from 'react-bootstrap';
+
+interface AdminPanelLayoutProps {
+  defaultActivePanel?: '#statistics'|'#cluster-management'|'#user-management';
+}
+
+export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
+  <Layout>
+    <h1>Admin Console</h1>
+    <TabContainer defaultActiveKey={(props.defaultActivePanel) ? props.defaultActivePanel : '#statistics'}>
+      <Col sm={4}>
+        <ListGroup>
+          <ListGroupItem action={true} href='#statistics'>Application Statistics</ListGroupItem>
+          <ListGroupItem action={true} href='#cluster-management'>Cluster Management</ListGroupItem>
+          <ListGroupItem action={true} href='#user-management'>Cluster Management</ListGroupItem>
+        </ListGroup>
+      </Col>
+      <Col sm={8}>
+        <TabContent>
+          <TabPane eventKey='#statistics'>
+            <p>The statistics panel is still under construction</p>
+          </TabPane>
+          <TabPane eventKey='#cluster-management'>
+            <p>The cluster management panel is still under construction</p>
+          </TabPane>
+          <TabPane eventKey='#user-management'>
+            <p>The user-management panel is still under construction</p>
+          </TabPane>
+        </TabContent>
+      </Col>
+    </TabContainer>
+  </Layout>
+);

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Layout} from '../../pages/Layout/Layout';
-import {Col, ListGroup, ListGroupItem, TabContainer, TabContent, TabPane} from 'react-bootstrap';
+import {Col, ListGroup, ListGroupItem, Row, TabContainer, TabContent, TabPane} from 'react-bootstrap';
 
 interface AdminPanelLayoutProps {
   defaultActivePanel?: '#statistics'|'#cluster-management'|'#user-management';
@@ -10,26 +10,28 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
   <Layout>
     <h1>Admin Console</h1>
     <TabContainer defaultActiveKey={(props.defaultActivePanel) ? props.defaultActivePanel : '#statistics'}>
-      <Col sm={4}>
-        <ListGroup>
-          <ListGroupItem action={true} href='#statistics'>Application Statistics</ListGroupItem>
-          <ListGroupItem action={true} href='#cluster-management'>Cluster Management</ListGroupItem>
-          <ListGroupItem action={true} href='#user-management'>Cluster Management</ListGroupItem>
-        </ListGroup>
-      </Col>
-      <Col sm={8}>
-        <TabContent>
-          <TabPane eventKey='#statistics'>
-            <p>The statistics panel is still under construction</p>
-          </TabPane>
-          <TabPane eventKey='#cluster-management'>
-            <p>The cluster management panel is still under construction</p>
-          </TabPane>
-          <TabPane eventKey='#user-management'>
-            <p>The user-management panel is still under construction</p>
-          </TabPane>
-        </TabContent>
-      </Col>
+      <Row>
+        <Col xs={4}>
+          <ListGroup>
+            <ListGroupItem variant='danger' action={true} href='#statistics'>Application Statistics</ListGroupItem>
+            <ListGroupItem variant='danger' action={true} href='#cluster-management'>Cluster Management</ListGroupItem>
+            <ListGroupItem variant='danger' action={true} href='#user-management'>Cluster Management</ListGroupItem>
+          </ListGroup>
+        </Col>
+        <Col xs={8}>
+          <TabContent>
+            <TabPane eventKey='#statistics'>
+              <p>The statistics panel is still under construction</p>
+            </TabPane>
+            <TabPane eventKey='#cluster-management'>
+              <p>The cluster management panel is still under construction</p>
+            </TabPane>
+            <TabPane eventKey='#user-management'>
+              <p>The user-management panel is still under construction</p>
+            </TabPane>
+          </TabContent>
+        </Col>
+      </Row>
     </TabContainer>
   </Layout>
 );

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -3,7 +3,7 @@ import {Layout} from '../../pages/Layout/Layout';
 import {Col, ListGroup, Row, TabContainer, TabContent, TabPane} from 'react-bootstrap';
 import {StatisticsPane} from './StatisticsPane';
 import {ClusterPane} from './ClusterPane';
-// import UsersPane from './UsersPane';
+import UsersPane from './UsersPane';
 import {DowntimeScheduler} from './DowntimeScheduler';
 
 interface AdminPanelLayoutProps {
@@ -11,10 +11,10 @@ interface AdminPanelLayoutProps {
 }
 
 const panes = [
-  {label: 'Application Statistics', eventKey: '#statistics', component: StatisticsPane},
-  {label: 'Cluster Management', eventKey: '#cluster-management', component: ClusterPane},
-  // {label: 'User Management', eventKey: '#user-management', component: UsersPane},
-  {label: 'Downtime Scheduler', eventKey: '#downtime-scheduler', component: DowntimeScheduler}
+  {label: 'Application Statistics', eventKey: '#statistics', component: <StatisticsPane/>},
+  {label: 'Cluster Management', eventKey: '#cluster-management', component: <ClusterPane/>},
+  {label: 'User Management', eventKey: '#user-management', component: <UsersPane/>},
+  {label: 'Downtime Scheduler', eventKey: '#downtime-scheduler', component: <DowntimeScheduler/>}
 ];
 
 export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
@@ -35,7 +35,7 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
           <TabContent>
             {panes.map(pane => (
               <TabPane key={pane.eventKey} eventKey={pane.eventKey}>
-                {pane.component()}
+                {pane.component}
               </TabPane>
             ))}
           </TabContent>

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -5,9 +5,10 @@ import {StatisticsPane} from './StatisticsPane';
 import {ClusterPane} from './ClusterPane';
 import UsersPane from './UsersPane';
 import {DowntimeScheduler} from './DowntimeScheduler';
+import {cast} from '../../util';
 
 interface AdminPanelLayoutProps {
-  defaultActivePanel?: '#statistics'|'#cluster-management'|'#user-management';
+  defaultActivePanel?: AdminTabKeys;
 }
 
 const panes = [
@@ -15,12 +16,14 @@ const panes = [
   {label: 'Cluster Management', eventKey: '#cluster-management', component: <ClusterPane/>},
   {label: 'User Management', eventKey: '#user-management', component: <UsersPane/>},
   {label: 'Downtime Scheduler', eventKey: '#downtime-scheduler', component: <DowntimeScheduler/>}
-];
+] as const;
+
+type AdminTabKeys = typeof panes[number]['eventKey'];
 
 export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
   <Layout>
     <h1>Admin Console</h1>
-    <TabContainer defaultActiveKey={(props.defaultActivePanel) ? props.defaultActivePanel : '#statistics'}>
+    <TabContainer defaultActiveKey={cast<AdminTabKeys>(props.defaultActivePanel ? props.defaultActivePanel : '#statistics')}>
       <Row>
         <Col xs={4}>
           <ListGroup style={{marginTop: '20px'}}>

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import {Layout} from '../../pages/Layout/Layout';
-import {Col, ListGroup, ListGroupItem, Row, TabContainer, TabContent} from 'react-bootstrap';
+import {Col, ListGroup, Row, TabContainer, TabContent} from 'react-bootstrap';
 import {StatisticsPane} from './StatisticsPane';
 import {ClusterPane} from './ClusterPane';
 import UsersPane from './UsersPane';
+import {DowntimeScheduler} from './DowntimeScheduler';
 
 interface AdminPanelLayoutProps {
   defaultActivePanel?: '#statistics'|'#cluster-management'|'#user-management';
@@ -15,10 +16,19 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
     <TabContainer defaultActiveKey={(props.defaultActivePanel) ? props.defaultActivePanel : '#statistics'}>
       <Row>
         <Col xs={4}>
-          <ListGroup>
-            <ListGroupItem variant='danger' action={true} href='#statistics'>Application Statistics</ListGroupItem>
-            <ListGroupItem variant='danger' action={true} href='#cluster-management'>Cluster Management</ListGroupItem>
-            <ListGroupItem variant='danger' action={true} href='#user-management'>User Management</ListGroupItem>
+          <ListGroup style={styles.listGroup}>
+            <ListGroup.Item action={true} href='#statistics'>
+              <span>Application Statistics</span>
+            </ListGroup.Item>
+            <ListGroup.Item action={true} href='#cluster-management'>
+              <span>Cluster Management</span>
+              </ListGroup.Item>
+            <ListGroup.Item action={true} href='#user-management'>
+              <span>User Management</span>
+            </ListGroup.Item>
+            <ListGroup.Item action={true} href='#downtime-scheduler'>
+              <span>Downtime Scheduler</span>
+            </ListGroup.Item>
           </ListGroup>
         </Col>
         <Col xs={8}>
@@ -26,9 +36,19 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
             <StatisticsPane/>
             <ClusterPane/>
             <UsersPane/>
+            <DowntimeScheduler/>
           </TabContent>
         </Col>
       </Row>
     </TabContainer>
   </Layout>
 );
+
+const styles = {
+  listGroup: {
+    marginTop: '20px',
+    '&.active': {
+      backgroundColor: '#d9534f'
+    }
+  }
+};

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import {Layout} from '../../pages/Layout/Layout';
-import {Col, ListGroup, ListGroupItem, Row, TabContainer, TabContent, TabPane} from 'react-bootstrap';
+import {Col, ListGroup, ListGroupItem, Row, TabContainer, TabContent} from 'react-bootstrap';
+import {StatisticsPane} from './StatisticsPane';
+import {ClusterPane} from './ClusterPane';
+import {UsersPane} from './UsersPane';
 
 interface AdminPanelLayoutProps {
   defaultActivePanel?: '#statistics'|'#cluster-management'|'#user-management';
@@ -20,15 +23,9 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
         </Col>
         <Col xs={8}>
           <TabContent>
-            <TabPane eventKey='#statistics'>
-              <p>The statistics panel is still under construction</p>
-            </TabPane>
-            <TabPane eventKey='#cluster-management'>
-              <p>The cluster management panel is still under construction</p>
-            </TabPane>
-            <TabPane eventKey='#user-management'>
-              <p>The user-management panel is still under construction</p>
-            </TabPane>
+            <StatisticsPane/>
+            <ClusterPane/>
+            <UsersPane/>
           </TabContent>
         </Col>
       </Row>

--- a/src/components/AdminPanelLayout/AdminPanelLayout.tsx
+++ b/src/components/AdminPanelLayout/AdminPanelLayout.tsx
@@ -3,7 +3,7 @@ import {Layout} from '../../pages/Layout/Layout';
 import {Col, ListGroup, Row, TabContainer, TabContent, TabPane} from 'react-bootstrap';
 import {StatisticsPane} from './StatisticsPane';
 import {ClusterPane} from './ClusterPane';
-import UsersPane from './UsersPane';
+// import UsersPane from './UsersPane';
 import {DowntimeScheduler} from './DowntimeScheduler';
 
 interface AdminPanelLayoutProps {
@@ -13,7 +13,7 @@ interface AdminPanelLayoutProps {
 const panes = [
   {label: 'Application Statistics', eventKey: '#statistics', component: StatisticsPane},
   {label: 'Cluster Management', eventKey: '#cluster-management', component: ClusterPane},
-  {label: 'User Management', eventKey: '#user-management', component: UsersPane},
+  // {label: 'User Management', eventKey: '#user-management', component: UsersPane},
   {label: 'Downtime Scheduler', eventKey: '#downtime-scheduler', component: DowntimeScheduler}
 ];
 
@@ -35,7 +35,7 @@ export const AdminPanelLayout = (props: AdminPanelLayoutProps) => (
           <TabContent>
             {panes.map(pane => (
               <TabPane key={pane.eventKey} eventKey={pane.eventKey}>
-                {pane.component}
+                {pane.component()}
               </TabPane>
             ))}
           </TabContent>

--- a/src/components/AdminPanelLayout/ClusterPane.tsx
+++ b/src/components/AdminPanelLayout/ClusterPane.tsx
@@ -1,0 +1,8 @@
+import {TabPane} from 'react-bootstrap';
+import React from 'react';
+
+export const ClusterPane = () => (
+  <TabPane eventKey='#cluster-management'>
+    <p>The cluster management panel is still under construction</p>
+  </TabPane>
+);

--- a/src/components/AdminPanelLayout/ClusterPane.tsx
+++ b/src/components/AdminPanelLayout/ClusterPane.tsx
@@ -1,8 +1,5 @@
-import {TabPane} from 'react-bootstrap';
 import React from 'react';
 
 export const ClusterPane = () => (
-  <TabPane eventKey='#cluster-management'>
-    <p>The cluster management panel is still under construction</p>
-  </TabPane>
+  <>The cluster management panel is still under construction</>
 );

--- a/src/components/AdminPanelLayout/DowntimeScheduler.tsx
+++ b/src/components/AdminPanelLayout/DowntimeScheduler.tsx
@@ -1,8 +1,5 @@
-import {TabPane} from 'react-bootstrap';
 import React from 'react';
 
 export const DowntimeScheduler = () => (
-  <TabPane eventKey='#downtime-scheduler'>
-    <p>The downtime scheduler panel is still under construction</p>
-  </TabPane>
+  <p>The downtime scheduler panel is still under construction</p>
 );

--- a/src/components/AdminPanelLayout/DowntimeScheduler.tsx
+++ b/src/components/AdminPanelLayout/DowntimeScheduler.tsx
@@ -1,0 +1,8 @@
+import {TabPane} from 'react-bootstrap';
+import React from 'react';
+
+export const DowntimeScheduler = () => (
+  <TabPane eventKey='#downtime-scheduler'>
+    <p>The downtime scheduler panel is still under construction</p>
+  </TabPane>
+);

--- a/src/components/AdminPanelLayout/StatisticsPane.tsx
+++ b/src/components/AdminPanelLayout/StatisticsPane.tsx
@@ -1,8 +1,5 @@
-import {TabPane} from 'react-bootstrap';
 import React from 'react';
 
 export const StatisticsPane = () => (
-  <TabPane eventKey='#statistics'>
-    <p>The statistics panel is still under construction</p>
-  </TabPane>
+  <p>The statistics panel is still under construction</p>
 );

--- a/src/components/AdminPanelLayout/StatisticsPane.tsx
+++ b/src/components/AdminPanelLayout/StatisticsPane.tsx
@@ -1,0 +1,8 @@
+import {TabPane} from 'react-bootstrap';
+import React from 'react';
+
+export const StatisticsPane = () => (
+  <TabPane eventKey='#statistics'>
+    <p>The statistics panel is still under construction</p>
+  </TabPane>
+);

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -16,6 +16,9 @@ class UsersPane extends React.Component<{}, UsersPaneState> {
   constructor(props: {}) {
     super(props);
     this.renderNoUsers();
+  }
+
+  componentWillMount() {
     this.loadUsers();
   }
 
@@ -27,33 +30,42 @@ class UsersPane extends React.Component<{}, UsersPaneState> {
   renderNoUsers() {
     return (
       <div style={{textAlign: 'center', marginTop: '2rem'}}>
-        <h6>Loading registered users.</h6>
+        <h6>There was an error loading registered users.</h6>
       </div>
     );
   }
 
-  // TODO: figure out how to get this list to flow horizontally
+
   render() {
     return (
       this.state.users.map((u) =>
         <TabPane key='user-management' eventKey='#user-management'>
           <ListGroup>
-            <ListGroup key={u.id}>
-              <ListGroupItem key={u.firstName}>
+            <ListGroupItem key={u.id}>
+              <span style={styles.userSpan}>
                 {u.firstName}
-              </ListGroupItem>
-              <ListGroupItem key={u.lastName}>
+              </span>
+              <span style={styles.userSpan}>
                 {u.lastName}
-              </ListGroupItem>
-              <ListGroupItem key={u.role}>
+              </span>
+              <span style={styles.userSpan}>
+                {u.email}
+              </span>
+              <span style={styles.userSpan}>
                 {u.role}
-              </ListGroupItem>
-            </ListGroup>
+              </span>
+            </ListGroupItem>
           </ListGroup>
         </TabPane>
       )
     );
   }
 }
+
+const styles = {
+  userSpan: {
+    margin: '10px'
+  }
+};
 
 export default UsersPane;

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -15,7 +15,6 @@ class UsersPane extends React.Component<{}, UsersPaneState> {
 
   constructor(props: {}) {
     super(props);
-    this.renderNoUsers();
   }
 
   componentWillMount() {
@@ -24,17 +23,8 @@ class UsersPane extends React.Component<{}, UsersPaneState> {
 
   async loadUsers() {
     const users = await getUserList();
-    this.setState({ users: users});
+    this.setState({users: users});
   }
-
-  renderNoUsers() {
-    return (
-      <div style={{textAlign: 'center', marginTop: '2rem'}}>
-        <h6>There was an error loading registered users.</h6>
-      </div>
-    );
-  }
-
 
   render() {
     return (
@@ -42,16 +32,16 @@ class UsersPane extends React.Component<{}, UsersPaneState> {
         <TabPane key='user-management' eventKey='#user-management'>
           <ListGroup>
             <ListGroupItem key={u.id}>
-              <span style={styles.userSpan}>
+              <span style={styles.nameSpan}>
                 {u.firstName}
               </span>
-              <span style={styles.userSpan}>
+              <span style={styles.nameSpan}>
                 {u.lastName}
               </span>
-              <span style={styles.userSpan}>
+              <span style={styles.emailSpan}>
                 {u.email}
               </span>
-              <span style={styles.userSpan}>
+              <span style={styles.roleSpan}>
                 {u.role}
               </span>
             </ListGroupItem>
@@ -63,8 +53,17 @@ class UsersPane extends React.Component<{}, UsersPaneState> {
 }
 
 const styles = {
-  userSpan: {
-    margin: '10px'
+  nameSpan: {
+    display: 'inline-block',
+    width: '25%'
+  },
+  emailSpan: {
+    display: 'inline-block',
+    width: '40%'
+  },
+  roleSpan: {
+    display: 'inline-block',
+    width: '10%'
   }
 };
 

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -1,8 +1,28 @@
-import {TabPane} from 'react-bootstrap';
+import {TabPane, ListGroup, ListGroupItem} from 'react-bootstrap';
 import React from 'react';
+
+// TODO: replace dummy data with actual data from database retrieved with API call(s)
+const users = [{'id':1, 'firstname':'John', 'lastname':'User', 'role':'Student'}, {'id':2, 'firstname':'Bill', 'lastname':'Buddy', 'role':'Admin'}];
+
+// TODO: figure out how to get this list to flow horizonally
+const userList = users.map((d) =>
+  <ListGroup key={d.id}>
+    <ListGroupItem key={d.firstname}>
+      {d.firstname}
+    </ListGroupItem>
+    <ListGroupItem key={d.lastname}>
+      {d.lastname}
+    </ListGroupItem>
+    <ListGroupItem key={d.role}>
+      {d.role}
+    </ListGroupItem>
+  </ListGroup>
+);
 
 export const UsersPane = () => (
   <TabPane eventKey='#user-management'>
-    <p>The user-management panel is still under construction</p>
+    <ListGroup>
+      {userList}
+    </ListGroup>
   </TabPane>
 );

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -1,4 +1,4 @@
-import {TabPane, Table} from 'react-bootstrap';
+import {Table} from 'react-bootstrap';
 import React from 'react';
 import {User} from '../../types/User';
 import {getUserList} from '../../api';
@@ -28,26 +28,24 @@ class UsersPane extends React.Component<{}, UsersPaneState> {
 
   render() {
     return (
-      <TabPane key='user-management' eventKey='#user-management'>
-        <Table striped={true} bordered={true} hover={true}>
-          <thead style={{backgroundColor: '#adb5bd'}}>
-          <tr>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Role</th>
+      <Table striped={true} bordered={true} hover={true}>
+        <thead style={{backgroundColor: '#adb5bd'}}>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Role</th>
+        </tr>
+        </thead>
+        <tbody>
+        {this.state.users.map((u) => (
+          <tr key={u.id} style={{cursor: 'pointer'}}>
+            <td>{u.firstName} {u.lastName}</td>
+            <td>{u.email}</td>
+            <td>{u.role}</td>
           </tr>
-          </thead>
-          <tbody>
-          {this.state.users.map((u) => (
-            <tr key={u.id} style={{cursor: 'pointer'}}>
-              <td>{u.firstName} {u.lastName}</td>
-              <td>{u.email}</td>
-              <td>{u.role}</td>
-            </tr>
-          ))}
-          </tbody>
-        </Table>
-      </TabPane>
+        ))}
+        </tbody>
+      </Table>
     );
   }
 }

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -16,7 +16,7 @@ const UsersPane = () => {
     setLoading(false);
   });
 
-  return <Layout>{loading ? <HorizontallyCenteredSpinner/> :
+  return <Layout>{loading ? <HorizontallyCenteredSpinner/> : (
     <Table striped={true} bordered={true} hover={true}>
       <thead style={{backgroundColor: '#adb5bd'}}>
       <tr>
@@ -35,7 +35,7 @@ const UsersPane = () => {
       ))}
       </tbody>
     </Table>
-  }</Layout>;
+  )}</Layout>;
 
 };
 

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -1,4 +1,4 @@
-import {TabPane, ListGroup, ListGroupItem} from 'react-bootstrap';
+import {TabPane, Table} from 'react-bootstrap';
 import React from 'react';
 import {User} from '../../types/User';
 import {getUserList} from '../../api';
@@ -28,43 +28,28 @@ class UsersPane extends React.Component<{}, UsersPaneState> {
 
   render() {
     return (
-      this.state.users.map((u) =>
-        <TabPane key='user-management' eventKey='#user-management'>
-          <ListGroup>
-            <ListGroupItem key={u.id}>
-              <span style={styles.nameSpan}>
-                {u.firstName}
-              </span>
-              <span style={styles.nameSpan}>
-                {u.lastName}
-              </span>
-              <span style={styles.emailSpan}>
-                {u.email}
-              </span>
-              <span style={styles.roleSpan}>
-                {u.role}
-              </span>
-            </ListGroupItem>
-          </ListGroup>
-        </TabPane>
-      )
+      <TabPane key='user-management' eventKey='#user-management'>
+        <Table striped={true} bordered={true} hover={true}>
+          <thead style={{backgroundColor: '#adb5bd'}}>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Role</th>
+          </tr>
+          </thead>
+          <tbody>
+          {this.state.users.map((u) => (
+            <tr key={u.id} style={{cursor: 'pointer'}}>
+              <td>{u.firstName} {u.lastName}</td>
+              <td>{u.email}</td>
+              <td>{u.role}</td>
+            </tr>
+          ))}
+          </tbody>
+        </Table>
+      </TabPane>
     );
   }
 }
-
-const styles = {
-  nameSpan: {
-    display: 'inline-block',
-    width: '25%'
-  },
-  emailSpan: {
-    display: 'inline-block',
-    width: '40%'
-  },
-  roleSpan: {
-    display: 'inline-block',
-    width: '10%'
-  }
-};
 
 export default UsersPane;

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 // TODO: replace dummy data with actual data from database retrieved with API call(s)
 const users = [{'id':1, 'firstname':'John', 'lastname':'User', 'role':'Student'}, {'id':2, 'firstname':'Bill', 'lastname':'Buddy', 'role':'Admin'}];
 
-// TODO: figure out how to get this list to flow horizonally
+// TODO: figure out how to get this list to flow horizontally
 const userList = users.map((d) =>
   <ListGroup key={d.id}>
     <ListGroupItem key={d.firstname}>

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -1,28 +1,59 @@
 import {TabPane, ListGroup, ListGroupItem} from 'react-bootstrap';
 import React from 'react';
+import {User} from '../../types/User';
+import {getUserList} from '../../api';
 
-// TODO: replace dummy data with actual data from database retrieved with API call(s)
-const users = [{'id':1, 'firstname':'John', 'lastname':'User', 'role':'Student'}, {'id':2, 'firstname':'Bill', 'lastname':'Buddy', 'role':'Admin'}];
+interface UsersPaneState {
+  users: User[];
+}
 
-// TODO: figure out how to get this list to flow horizontally
-const userList = users.map((d) =>
-  <ListGroup key={d.id}>
-    <ListGroupItem key={d.firstname}>
-      {d.firstname}
-    </ListGroupItem>
-    <ListGroupItem key={d.lastname}>
-      {d.lastname}
-    </ListGroupItem>
-    <ListGroupItem key={d.role}>
-      {d.role}
-    </ListGroupItem>
-  </ListGroup>
-);
+class UsersPane extends React.Component<{}, UsersPaneState> {
 
-export const UsersPane = () => (
-  <TabPane eventKey='#user-management'>
-    <ListGroup>
-      {userList}
-    </ListGroup>
-  </TabPane>
-);
+  state:UsersPaneState = {
+    users: []
+  };
+
+  constructor(props: {}) {
+    super(props);
+    this.renderNoUsers();
+    this.loadUsers();
+  }
+
+  async loadUsers() {
+    const users = await getUserList();
+    this.setState({ users: users});
+  }
+
+  renderNoUsers() {
+    return (
+      <div style={{textAlign: 'center', marginTop: '2rem'}}>
+        <h6>Loading registered users.</h6>
+      </div>
+    );
+  }
+
+  // TODO: figure out how to get this list to flow horizontally
+  render() {
+    return (
+      this.state.users.map((u) =>
+        <TabPane key='user-management' eventKey='#user-management'>
+          <ListGroup>
+            <ListGroup key={u.id}>
+              <ListGroupItem key={u.firstName}>
+                {u.firstName}
+              </ListGroupItem>
+              <ListGroupItem key={u.lastName}>
+                {u.lastName}
+              </ListGroupItem>
+              <ListGroupItem key={u.role}>
+                {u.role}
+              </ListGroupItem>
+            </ListGroup>
+          </ListGroup>
+        </TabPane>
+      )
+    );
+  }
+}
+
+export default UsersPane;

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -1,0 +1,8 @@
+import {TabPane} from 'react-bootstrap';
+import React from 'react';
+
+export const UsersPane = () => (
+  <TabPane eventKey='#user-management'>
+    <p>The user-management panel is still under construction</p>
+  </TabPane>
+);

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -1,53 +1,79 @@
 import {Table} from 'react-bootstrap';
-import React from 'react';
+import React, {useState} from 'react';
 import {User} from '../../types/User';
 import {getUserList} from '../../api';
+import {useMount} from '../../hooks/useMount';
+import {HorizontallyCenteredSpinner} from '../util/HorizonallyCenteredSpinner';
+import {Layout} from '../../pages/Layout/Layout';
 
-interface UsersPaneState {
-  users: User[];
-}
 
-class UsersPane extends React.Component<{}, UsersPaneState> {
+const UsersPane = () => {
+  const [users, setUsers] = useState();
+  const [loading, setLoading] = useState(true);
 
-  state:UsersPaneState = {
-    users: []
-  };
+  useMount(async () => {
+    setUsers(await getUserList());
+    completeLoading();
+  });
 
-  constructor(props: {}) {
-    super(props);
+  function completeLoading() {
+    setLoading(false);
   }
 
-  componentWillMount() {
-    this.loadUsers();
-  }
-
-  async loadUsers() {
-    const users = await getUserList();
-    this.setState({users: users});
-  }
-
-  render() {
-    return (
-      <Table striped={true} bordered={true} hover={true}>
-        <thead style={{backgroundColor: '#adb5bd'}}>
-        <tr>
-          <th>Name</th>
-          <th>Email</th>
-          <th>Role</th>
+  const renderUserList = () => (
+    <Table striped={true} bordered={true} hover={true}>
+      <thead style={{backgroundColor: '#adb5bd'}}>
+      <tr>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Role</th>
+      </tr>
+      </thead>
+      <tbody>
+      {users.map((u: User) => (
+        <tr key={u.id} style={{cursor: 'pointer'}}>
+          <td>{u.firstName} {u.lastName}</td>
+          <td>{u.email}</td>
+          <td>{u.role}</td>
         </tr>
-        </thead>
-        <tbody>
-        {this.state.users.map((u) => (
-          <tr key={u.id} style={{cursor: 'pointer'}}>
-            <td>{u.firstName} {u.lastName}</td>
-            <td>{u.email}</td>
-            <td>{u.role}</td>
-          </tr>
-        ))}
-        </tbody>
-      </Table>
-    );
-  }
-}
+      ))}
+      </tbody>
+    </Table>
+  );
+
+  return <Layout>{loading ? <HorizontallyCenteredSpinner/> : renderUserList()}</Layout>;
+
+};
 
 export default UsersPane;
+
+// interface UsersPaneState {
+//   users: User[];
+// }
+//
+// class UsersPane extends React.Component<{}, UsersPaneState> {
+//
+//   state:UsersPaneState = {
+//     users: []
+//   };
+//
+//   constructor(props: {}) {
+//     super(props);
+//   }
+//
+//   componentWillMount() {
+//     this.loadUsers();
+//   }
+//
+//   async loadUsers() {
+//     const users = await getUserList();
+//     this.setState({users: users});
+//   }
+//
+//   render() {
+//     return (
+//     );
+//   }
+// }
+//
+// export default UsersPane;

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -16,7 +16,7 @@ const UsersPane = () => {
     setLoading(false);
   });
 
-  return <Layout>{loading ? <HorizontallyCenteredSpinner/> : () => (
+  return <Layout>{loading ? <HorizontallyCenteredSpinner/> :
     <Table striped={true} bordered={true} hover={true}>
       <thead style={{backgroundColor: '#adb5bd'}}>
       <tr>
@@ -35,7 +35,7 @@ const UsersPane = () => {
       ))}
       </tbody>
     </Table>
-  )}</Layout>;
+  }</Layout>;
 
 };
 

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -46,34 +46,3 @@ const UsersPane = () => {
 };
 
 export default UsersPane;
-
-// interface UsersPaneState {
-//   users: User[];
-// }
-//
-// class UsersPane extends React.Component<{}, UsersPaneState> {
-//
-//   state:UsersPaneState = {
-//     users: []
-//   };
-//
-//   constructor(props: {}) {
-//     super(props);
-//   }
-//
-//   componentWillMount() {
-//     this.loadUsers();
-//   }
-//
-//   async loadUsers() {
-//     const users = await getUserList();
-//     this.setState({users: users});
-//   }
-//
-//   render() {
-//     return (
-//     );
-//   }
-// }
-//
-// export default UsersPane;

--- a/src/components/AdminPanelLayout/UsersPane.tsx
+++ b/src/components/AdminPanelLayout/UsersPane.tsx
@@ -13,14 +13,10 @@ const UsersPane = () => {
 
   useMount(async () => {
     setUsers(await getUserList());
-    completeLoading();
+    setLoading(false);
   });
 
-  function completeLoading() {
-    setLoading(false);
-  }
-
-  const renderUserList = () => (
+  return <Layout>{loading ? <HorizontallyCenteredSpinner/> : () => (
     <Table striped={true} bordered={true} hover={true}>
       <thead style={{backgroundColor: '#adb5bd'}}>
       <tr>
@@ -39,9 +35,7 @@ const UsersPane = () => {
       ))}
       </tbody>
     </Table>
-  );
-
-  return <Layout>{loading ? <HorizontallyCenteredSpinner/> : renderUserList()}</Layout>;
+  )}</Layout>;
 
 };
 

--- a/src/hooks/useMount.ts
+++ b/src/hooks/useMount.ts
@@ -1,0 +1,6 @@
+import {EffectCallback, useEffect} from 'react';
+
+export function useMount(func: EffectCallback | (() => Promise<any>) | (() => any)) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {func(); }, []);
+}

--- a/src/pages/AdminPanel/AdminPanel.tsx
+++ b/src/pages/AdminPanel/AdminPanel.tsx
@@ -6,7 +6,6 @@ import {AdminPanelLayout} from '../../components/AdminPanelLayout/AdminPanelLayo
 const AdminPage = () => (
   <Layout>
     <div className={styles['not-found']}>
-      <label>This page is still under construction.</label>
       <AdminPanelLayout/>
     </div>
   </Layout>

--- a/src/pages/AdminPanel/AdminPanel.tsx
+++ b/src/pages/AdminPanel/AdminPanel.tsx
@@ -1,11 +1,10 @@
 import {Layout} from '../Layout/Layout';
-import styles from './AdminPanel.scss';
 import React from 'react';
 import {AdminPanelLayout} from '../../components/AdminPanelLayout/AdminPanelLayout';
 
 const AdminPage = () => (
   <Layout>
-    <div className={styles['not-found']}>
+    <div>
       <AdminPanelLayout/>
     </div>
   </Layout>

--- a/src/pages/AdminPanel/AdminPanel.tsx
+++ b/src/pages/AdminPanel/AdminPanel.tsx
@@ -1,11 +1,13 @@
 import {Layout} from '../Layout/Layout';
 import styles from './AdminPanel.scss';
 import React from 'react';
+import {AdminPanelLayout} from '../../components/AdminPanelLayout/AdminPanelLayout';
 
 const AdminPage = () => (
   <Layout>
     <div className={styles['not-found']}>
       <label>This page is still under construction.</label>
+      <AdminPanelLayout/>
     </div>
   </Layout>
 );


### PR DESCRIPTION
This PR mostly focuses on [this Trello card.](https://trello.com/c/JbXjmmXl)

It also includes a few other odds and ends that had to be put in place to support this feature, and a few miscellaneous maintenance things. These are:

- An update to the admin console to provide a list of views that an admin can flip between. All these views are just hardcoded placeholders right now, except for the user list.
- An API method to get the list of users from the backend.
- An update to the readme detailing the new git workflow using the dev branch.