### PR TITLE
Change display of modules

### DIFF
--- a/src/pages/Explore/Explore.tsx
+++ b/src/pages/Explore/Explore.tsx
@@ -1,4 +1,4 @@
-import {CardColumns} from 'react-bootstrap';
+import {Row, Col} from 'react-bootstrap';
 import React from 'react';
 import {ModuleCard} from '../../components/ModuleCard/ModuleCard';
 import {Module} from '../../types/Module';
@@ -35,7 +35,10 @@ class Explore extends React.Component<{}, ExploreState> {
   }
 
   render() {
-    const cards = this.state.modules.map((m, i) => <ModuleCard buttonLink={'/module/' + m.id} module={m} key={i}/>);
+    const cards = this.state.modules.map((m, i) => 
+      <Col key={i} className='col-md-6 col-lg-4'>
+        <ModuleCard buttonLink={'/module/' + m.id} module={m} key={i}/>
+      </Col>);
     return (
       <Layout>
         {this.state.state === 'loading' ? <HorizontallyCenteredSpinner/> :
@@ -45,7 +48,7 @@ class Explore extends React.Component<{}, ExploreState> {
               <PageTitle>Explore</PageTitle>
               {cards.length === 0 ?
                 <p style={{textAlign: 'center', marginTop: '1rem'}}>No modules published at this time, please come back later.</p> :
-                <CardColumns>{cards}</CardColumns>
+                <Row className='g-4'>{cards}</Row>
               }
 
             </>

--- a/src/pages/MyModules/MyModules.tsx
+++ b/src/pages/MyModules/MyModules.tsx
@@ -1,4 +1,4 @@
-import {CardColumns} from 'react-bootstrap';
+import {Row, Col} from 'react-bootstrap';
 import React from 'react';
 import {ModuleCard} from '../../components/ModuleCard/ModuleCard';
 import {getUserModules} from '../../api';
@@ -36,11 +36,14 @@ class MyModules extends React.Component<{}, MyModulesState> {
   }
 
   render() {
-      const cards = this.state.modules.map((m, i) => <ModuleCard buttonLink={RoutePaths.userModule.replace(':id', String(m.id))} module={m} key={i}/>);
+      const cards = this.state.modules.map((m, i) => 
+        <Col key={i} className='col-md-6 col-lg-4'>
+          <ModuleCard buttonLink={RoutePaths.userModule.replace(':id', String(m.id))} module={m} key={i}/>
+        </Col>);
       return (
         <Layout>
           <h1>My Modules</h1>
-          {cards.length === 0 ? this.renderNoModules() : <CardColumns>{cards}</CardColumns>}
+          {cards.length === 0 ? this.renderNoModules() : <Row className='g-4'>{cards}</Row>}
         </Layout>
       );
   }


### PR DESCRIPTION
Use Row and Col instead of CardColumns for better display of modules.

Before:
![module-cards](https://user-images.githubusercontent.com/62122448/142084064-b0f4aa35-5696-44ed-8d58-da6a55875a30.gif)

After:
![fixed-module-cards](https://user-images.githubusercontent.com/62122448/142084089-510ceba1-1b5e-4e02-b510-2738a043cc32.gif)

