### PR TITLE
Zh/Do not display temp lab time/extension for other lab types

### DIFF
--- a/src/components/LabEnvironment/LabEnvironment.tsx
+++ b/src/components/LabEnvironment/LabEnvironment.tsx
@@ -129,8 +129,9 @@ export class LabEnvironment extends Component<LabEnvironmentProps, LabEnvironmen
                 loading={this.props.starting}
                 label='Start Lab'
                 onClick={this.props.onStartLab} 
-              /> : <h6 style={{textAlign: 'right'}}>Lab's time remaining: {getRemainingLabTime(this.state.labEndDateTime)}
-              {this.showExtendButton()}</h6>}
+              /> : this.props.userLab.lab.type === 'Temporary' &&
+              <h6 style={{textAlign: 'right'}}>Lab's time remaining: {getRemainingLabTime(this.state.labEndDateTime)}{this.showExtendButton()}</h6>
+            }
           </Row>
           <Row className='fill-height'>
             <Col sm={4} md={4} lg={2}>


### PR DESCRIPTION
Only displays extend and remaining options when the lab is temporary:

![lab-time-change](https://user-images.githubusercontent.com/62122448/144146637-ebab6d0b-b1a0-4a4e-b815-da3d96506022.gif)